### PR TITLE
Add finalizer to the secretshare

### DIFF
--- a/pkg/apis/ibmcpcs/v1/secretshare_types.go
+++ b/pkg/apis/ibmcpcs/v1/secretshare_types.go
@@ -87,3 +87,34 @@ type SecretShareList struct {
 func init() {
 	SchemeBuilder.Register(&SecretShare{}, &SecretShareList{})
 }
+
+// RemoveFinalizer removes the operator source finalizer from the
+// SecretShare ObjectMeta.
+func (r *SecretShare) RemoveFinalizer() bool {
+	outFinalizers := make([]string, 0)
+	var changed bool
+	for _, finalizer := range r.ObjectMeta.Finalizers {
+		if finalizer == "finalizer.secretshare.ibm.com" {
+			changed = true
+			continue
+		}
+		outFinalizers = append(outFinalizers, finalizer)
+	}
+
+	r.ObjectMeta.Finalizers = outFinalizers
+	return changed
+}
+
+// EnsureFinalizer ensures that the operator source finalizer is included
+// in the ObjectMeta.Finalizer slice. If it already exists, no state change occurs.
+// If it doesn't, the finalizer is appended to the slice.
+func (r *SecretShare) EnsureFinalizer() bool {
+	for _, finalizer := range r.ObjectMeta.Finalizers {
+		if finalizer == "finalizer.secretshare.ibm.com" {
+			return false
+		}
+	}
+
+	r.ObjectMeta.Finalizers = append(r.ObjectMeta.Finalizers, "finalizer.secretshare.ibm.com")
+	return true
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The secretshare finalizer is used to manage the lifecycle of the copied secrets and configmaps.

When secretshare instance is deleted, the copied secrets and configmaps will be cleaned up along with the secretshare instance.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
