### PR TITLE
Don't requeue the request when the secret/configmap provider isn't enabled

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -102,10 +103,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	retryPeriod := 5 * time.Minute
+
 	// Set default manager options
 	options := manager.Options{
 		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		RetryPeriod:        &retryPeriod,
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/IBM/ibm-secretshare-operator
 go 1.13
 
 require (
+	github.com/operator-framework/operator-lifecycle-manager v3.11.0+incompatible
 	github.com/operator-framework/operator-sdk v0.18.0
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ github.com/coreos/etcd v3.3.17+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -640,6 +641,8 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/operator-framework/api v0.1.1/go.mod h1:yzNYR7qyJqRGOOp+bT6Z/iYSbSPNxeh3Si93Gx/3OBY=
 github.com/operator-framework/api v0.3.4/go.mod h1:TmRmw+8XOUaDPq6SP9gA8cIexNf/Pq8LMFY7YaKQFTs=
 github.com/operator-framework/api v0.3.7-0.20200528122852-759ca0d84007/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
+github.com/operator-framework/operator-lifecycle-manager v3.11.0+incompatible h1:Po8C8RVLRWq7pNQ5pKonM9CXpC/osoBWbmsuf+HJnSI=
+github.com/operator-framework/operator-lifecycle-manager v3.11.0+incompatible/go.mod h1:Ma5ZXd4S1vmMyewWlF7aO8CZiokR7Sd8dhSfkGkNU4U=
 github.com/operator-framework/operator-registry v1.5.3/go.mod h1:agrQlkWOo1q8U1SAaLSS2WQ+Z9vswNT2M2HFib9iuLY=
 github.com/operator-framework/operator-registry v1.12.1/go.mod h1:rf4b/h77GUv1+geiej2KzGRQr8iBLF4dXNwr5AuGkrQ=
 github.com/operator-framework/operator-registry v1.12.4/go.mod h1:JChIivJVLE1wRbgIhDFzYQYT9yosa2wd6qiTyMuG5mg=

--- a/pkg/controller/secretshare/constant.go
+++ b/pkg/controller/secretshare/constant.go
@@ -1,0 +1,36 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package secretshare
+
+var (
+	secretOperatorMapping = map[string]string{
+		"cs-ca-certificate-secret":    "ibm-cert-manager-operator",
+		"ibmcloud-cluster-ca-cert":    "ibm-management-ingress-operator",
+		"icp-metering-api-secret":     "ibm-metering-operator",
+		"icp-mongodb-admin":           "ibm-mongodb-operator",
+		"icp-mongodb-client-cert":     "ibm-mongodb-operator",
+		"icp-serviceid-apikey-secret": "ibm-iam-operator",
+		"oauth-client-secret":         "ibm-iam-operator",
+		"platform-oidc-credentials":   "ibm-iam-operator",
+	}
+
+	cmOperatorMapping = map[string]string{
+		"ibmcloud-cluster-info": "ibm-management-ingress-operator",
+		"platform-auth-idp":     "ibm-iam-operator",
+		"oauth-client-map":      "ibm-iam-operator",
+	}
+)

--- a/pkg/controller/secretshare/subscription.go
+++ b/pkg/controller/secretshare/subscription.go
@@ -14,15 +14,22 @@
 // limitations under the License.
 //
 
-package apis
+package secretshare
 
 import (
-	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"context"
 
-	v1 "github.com/IBM/ibm-secretshare-operator/pkg/apis/ibmcpcs/v1"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 )
 
-func init() {
-	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, olmv1alpha1.SchemeBuilder.AddToScheme, v1.SchemeBuilder.AddToScheme)
+// checkSub gets the subscription
+func (r *ReconcileSecretShare) checkSub(name, namespace string) bool {
+	sub := &olmv1alpha1.Subscription{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, sub); err != nil {
+		klog.Error(err)
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR separates secret and configmap status.
- Watch the operator creating in the ibm-common-services namespace, then reconcile the secretshare `ibm-common-services/common-services`.
- Don't requeue the request when the operator providing secret/configmap isn't enabled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
