### PR TITLE
fix secret cm update issue

### DIFF
--- a/config/crd/bases/ibmcpcs.ibm.com_secretshares.yaml
+++ b/config/crd/bases/ibmcpcs.ibm.com_secretshares.yaml
@@ -101,7 +101,7 @@ spec:
             members:
               description: Members represnets the current operand status of the set
               properties:
-                ConfigmapMembers:
+                configmapMembers:
                   additionalProperties:
                     description: MemberPhase identifies the status of the
                     type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

It PR won't use the controllerutil.createOrUpdate to update the secret and configmaps.
It uses the `client.Create` and `client.Update` to deploy and update the secret and configmaps.

/assign @Daniel-Fan 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
