### PR TITLE
use ss name as prefix and ns as name for label key

### DIFF
--- a/controllers/configmap.go
+++ b/controllers/configmap.go
@@ -61,11 +61,11 @@ func (r *SecretShareReconciler) addLabelstoConfigmap(cm *corev1.ConfigMap, ss *i
 		existingCm.Labels = make(map[string]string)
 	}
 
-	ssValue := ss.Namespace + "." + ss.Name
+	ssKey := ss.Name + "/" + ss.Namespace
 	if len(existingCm.Labels["manage-by-secretshare"]) == 0 {
 		existingCm.Labels["manage-by-secretshare"] = "true"
 	}
-	existingCm.Labels["secretsharekey"] = ssValue
+	existingCm.Labels[ssKey] = "secretsharekey"
 
 	if err := r.Client.Update(context.TODO(), existingCm); err != nil {
 		return err

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -60,12 +60,12 @@ func (r *SecretShareReconciler) addLabelstoSecret(secret *corev1.Secret, ss *ibm
 	if existingSecret.Labels == nil {
 		existingSecret.Labels = make(map[string]string)
 	}
-	ssValue := ss.Namespace + "." + ss.Name
+	ssKey := ss.Name + "/" + ss.Namespace
 	if len(existingSecret.Labels["manage-by-secretshare"]) == 0 {
 		existingSecret.Labels["manage-by-secretshare"] = "true"
 	}
 
-	existingSecret.Labels["secretsharekey"] = ssValue
+	existingSecret.Labels[ssKey] = "secretsharekey"
 
 	if err := r.Client.Update(context.TODO(), existingSecret); err != nil {
 		return err

--- a/controllers/secretshare_controller.go
+++ b/controllers/secretshare_controller.go
@@ -303,12 +303,12 @@ func getCMSecretToSS() handler.ToRequestsFunc {
 		secretshare := []reconcile.Request{}
 		labels := object.Meta.GetLabels()
 		for ssKey, ss := range labels {
-			if ssKey == "secretsharekey" {
-				ssKeyList := strings.Split(ss, ".")
+			if ss == "secretsharekey" {
+				ssKeyList := strings.Split(ssKey, "/")
 				if len(ssKeyList) != 2 {
 					continue
 				}
-				secretshare = append(secretshare, reconcile.Request{NamespacedName: types.NamespacedName{Name: ssKeyList[1], Namespace: ssKeyList[0]}})
+				secretshare = append(secretshare, reconcile.Request{NamespacedName: types.NamespacedName{Name: ssKeyList[0], Namespace: ssKeyList[1]}})
 			}
 		}
 		return secretshare


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

Prefix of key value is 253 characters in total which is used for secretshare name
Name of key value is 63 characters in total which is used for secretshare namespace

They are separated by `/` in key value for label.

